### PR TITLE
No more page expired.

### DIFF
--- a/wicket-dnd/src/main/java/wicketdnd/DragSource.java
+++ b/wicket-dnd/src/main/java/wicketdnd/DragSource.java
@@ -34,11 +34,11 @@ import wicketdnd.util.MarkupIdVisitor;
 
 /**
  * A source of drags.
- * 
+ *
  * @see #getTypes()
  * @see #onBeforeDrop(Component, Transfer)
  * @see #onAfterDrop(AjaxRequestTarget, Transfer)
- * 
+ *
  * @author Sven Meier
  */
 public class DragSource extends Behavior
@@ -58,10 +58,10 @@ public class DragSource extends Behavior
 
 	/**
 	 * Create a source of drags.
-	 * 
+	 *
 	 * @param operations
 	 *            allowed operations
-	 * 
+	 *            
 	 * @see #getOperations()
 	 */
 	public DragSource(Operation... operations)
@@ -71,10 +71,10 @@ public class DragSource extends Behavior
 
 	/**
 	 * Create a source of drags.
-	 * 
+	 *
 	 * @param operations
 	 *            allowed operations
-	 * 
+	 *            
 	 * @see #getOperations()
 	 */
 	public DragSource(Set<Operation> operations)
@@ -84,7 +84,7 @@ public class DragSource extends Behavior
 
 	/**
 	 * Get supported types for a transfer.
-	 * 
+	 *
 	 * @return transfers
 	 * @see Transfer#getType()
 	 */
@@ -97,7 +97,7 @@ public class DragSource extends Behavior
 	 * Allow drag on elements matching the given selector.
 	 * 
 	 * Make sure all matching elements are configured to output their markup id.
-	 * 
+	 *
 	 * @param selector
 	 *            element selector
 	 * @see Component#setOutputMarkupId(boolean)
@@ -121,7 +121,7 @@ public class DragSource extends Behavior
 
 	/**
 	 * Initiate drag on elements matching the given selector.
-	 * 
+	 *
 	 * @param selector
 	 *            element selector
 	 */
@@ -133,7 +133,7 @@ public class DragSource extends Behavior
 
 	/**
 	 * Clone drag on elements matching the given selector.
-	 * 
+	 *
 	 * @param selector
 	 *            element selector
 	 */
@@ -152,7 +152,7 @@ public class DragSource extends Behavior
 
 	/**
 	 * Get the identifying path of this drag source.
-	 * 
+	 *
 	 * @return path in page
 	 */
 	public String getPath()
@@ -162,7 +162,7 @@ public class DragSource extends Behavior
 
 	/**
 	 * Get the id of this behavior.
-	 * 
+	 *
 	 * @return id
 	 */
 	public int getBehaviorId()
@@ -185,12 +185,11 @@ public class DragSource extends Behavior
 		final String id = component.getMarkupId();
 		final String path = component.getPageRelativePath();
 		int behavior = component.getBehaviorId(this);
-		
-		String initJS = String
-				.format("wicketdnd.dragSource('%s','%s','%s', %s,%s,{'select':'%s','initiate':'%s','clone':'%s'});",
-						id, behavior, path, new CollectionFormattable(getOperations()),
-						new CollectionFormattable(getTypes()), selector, initiateSelector,
-						cloneSelector);
+
+		String initJS = String.format(
+				"wicketdnd.dragSource('%s','%s','%s', %s,%s,{'select':'%s','initiate':'%s','clone':'%s'});", id,
+				behavior, path, new CollectionFormattable(getOperations()),
+				new CollectionFormattable(getTypes()), selector, initiateSelector, cloneSelector);
 		response.render(OnDomReadyHeaderItem.forScript(initJS));
 	}
 
@@ -204,7 +203,7 @@ public class DragSource extends Behavior
 
 	/**
 	 * Get supported operations.
-	 * 
+	 *
 	 * @return operations
 	 * @see Transfer#getOperation()
 	 */
@@ -232,11 +231,9 @@ public class DragSource extends Behavior
 
 	/**
 	 * Notification that a drop is about to happen - any implementation should
-	 * set the data on the given transfer or reject it.
-	 * 
-	 * The default implementation uses the component's model object as transfer
-	 * data.
-	 * 
+	 * set the data on the given transfer or reject it. The default
+	 * implementation uses the component's model object as transfer data.
+	 *
 	 * @param drag
 	 *            component to get data from
 	 * @param operation
@@ -255,9 +252,8 @@ public class DragSource extends Behavior
 
 	/**
 	 * Notification that a drop happened of one of this source's transfer datas.
-	 * 
 	 * The default implementation does nothing.
-	 * 
+	 *
 	 * @param target
 	 *            initiating request target
 	 * @param transfer
@@ -271,12 +267,12 @@ public class DragSource extends Behavior
 	{
 		String drag = request.getRequestParameters().getParameterValue("drag").toString();
 
-		return MarkupIdVisitor.getComponent((MarkupContainer)component, drag);
+		return MarkupIdVisitor.getComponent((MarkupContainer) component, drag);
 	}
 
 	/**
 	 * Get the drag source of the given request.
-	 * 
+	 *
 	 * @param request
 	 *            request on which a drag happened
 	 * @return drag source
@@ -290,7 +286,25 @@ public class DragSource extends Behavior
 			throw new PageExpiredException("No drag source found " + path);
 		}
 
-		int behavior =  request.getRequestParameters().getParameterValue("behavior").toInt();
-		return (DragSource)component.getBehaviorById(behavior);
+		int behavior = request.getRequestParameters().getParameterValue("behavior").toInt();
+		return (DragSource) component.getBehaviorById(behavior);
+	}
+
+	final static boolean getDragSourceExists(Page page, Request request)
+	{
+		String path = request.getRequestParameters().getParameterValue("path").toString();
+		Component component = page.get(path);
+		if (component == null)
+		{
+			return false;
+		}
+		return true;
+	}
+
+	public boolean getDragComponentExists(Request request)
+	{
+		String drag = request.getRequestParameters().getParameterValue("drag").toString();
+
+		return MarkupIdVisitor.getComponentExists((MarkupContainer) this.component, drag);
 	}
 }

--- a/wicket-dnd/src/main/java/wicketdnd/DropTarget.java
+++ b/wicket-dnd/src/main/java/wicketdnd/DropTarget.java
@@ -37,11 +37,10 @@ import wicketdnd.util.MarkupIdVisitor;
 /**
  * A target of drops. Can be configured for specific {@link Location}s via CSS
  * selectors.
- * 
+ *
  * @see #getTypes()
  * @see #onDrag(AjaxRequestTarget, Location)
  * @see #onDrop(AjaxRequestTarget, Transfer, Location)
- * 
  * @author Sven Meier
  */
 public class DropTarget extends AbstractDefaultAjaxBehavior
@@ -62,10 +61,9 @@ public class DropTarget extends AbstractDefaultAjaxBehavior
 
 	/**
 	 * Create a target for drop.
-	 * 
+	 *
 	 * @param operations
 	 *            allowed operations
-	 * 
 	 * @see #getOperations()
 	 */
 	public DropTarget(Operation... operations)
@@ -75,10 +73,9 @@ public class DropTarget extends AbstractDefaultAjaxBehavior
 
 	/**
 	 * Create a target for drop.
-	 * 
+	 *
 	 * @param operations
 	 *            allowed operations
-	 * 
 	 * @see #getOperations()
 	 */
 	public DropTarget(Set<Operation> operations)
@@ -88,7 +85,7 @@ public class DropTarget extends AbstractDefaultAjaxBehavior
 
 	/**
 	 * Get possible types for a transfer.
-	 * 
+	 *
 	 * @return transfers
 	 * @see Transfer#getType()
 	 */
@@ -99,10 +96,9 @@ public class DropTarget extends AbstractDefaultAjaxBehavior
 
 	/**
 	 * Allow drop on the {@link Anchor#CENTER} of elements matching the given
-	 * selector.
-	 * 
-	 * Make sure all matching elements are configured to output their markup id.
-	 * 
+	 * selector. Make sure all matching elements are configured to output their
+	 * markup id.
+	 *
 	 * @param selector
 	 *            element selector
 	 * @see Component#setOutputMarkupId(boolean)
@@ -115,10 +111,9 @@ public class DropTarget extends AbstractDefaultAjaxBehavior
 
 	/**
 	 * Allow drop on the {@link Anchor#TOP} of elements matching the given
-	 * selector.
-	 * 
-	 * Make sure all matching elements are configured to output their markup id.
-	 * 
+	 * selector. Make sure all matching elements are configured to output their
+	 * markup id.
+	 *
 	 * @param selector
 	 *            element selector
 	 * @see Component#setOutputMarkupId(boolean)
@@ -131,10 +126,9 @@ public class DropTarget extends AbstractDefaultAjaxBehavior
 
 	/**
 	 * Allow drop on the {@link Anchor#RIGHT} of elements matching the given
-	 * selector.
-	 * 
-	 * Make sure all matching elements are configured to output their markup id.
-	 * 
+	 * selector. Make sure all matching elements are configured to output their
+	 * markup id.
+	 *
 	 * @param selector
 	 *            element selector
 	 * @see Component#setOutputMarkupId(boolean)
@@ -147,10 +141,9 @@ public class DropTarget extends AbstractDefaultAjaxBehavior
 
 	/**
 	 * Allow drop on the {@link Anchor#BOTTOM} of elements matching the given
-	 * selector.
-	 * 
-	 * Make sure all matching elements are configured to output their markup id.
-	 * 
+	 * selector. Make sure all matching elements are configured to output their
+	 * markup id.
+	 *
 	 * @param selector
 	 *            element selector
 	 * @see Component#setOutputMarkupId(boolean)
@@ -163,10 +156,9 @@ public class DropTarget extends AbstractDefaultAjaxBehavior
 
 	/**
 	 * Allow drop on the {@link Anchor#LEFT} of elements matching the given
-	 * selector.
-	 * 
-	 * Make sure all matching elements are configured to output their markup id.
-	 * 
+	 * selector. Make sure all matching elements are configured to output their
+	 * markup id.
+	 *
 	 * @param selector
 	 *            element selector
 	 * @see Component#setOutputMarkupId(boolean)
@@ -213,10 +205,10 @@ public class DropTarget extends AbstractDefaultAjaxBehavior
 
 		final String id = getComponent().getMarkupId();
 		String initJS = String.format(
-				"new wicketdnd.dropTarget('%s',%s,%s,%s,{'center':'%s','top':'%s','right':'%s','bottom':'%s','left':'%s'});", id,
-				renderAjaxAttributes(getComponent()), new CollectionFormattable(getOperations()),
-				new CollectionFormattable(getTypes()), centerSelector, topSelector, rightSelector,
-				bottomSelector, leftSelector);
+				"new wicketdnd.dropTarget('%s',%s,%s,%s,{'center':'%s','top':'%s','right':'%s','bottom':'%s','left':'%s'});",
+				id, renderAjaxAttributes(getComponent()), new CollectionFormattable(getOperations()),
+				new CollectionFormattable(getTypes()), centerSelector, topSelector, rightSelector, bottomSelector,
+				leftSelector);
 		response.render(OnDomReadyHeaderItem.forScript(initJS));
 	}
 
@@ -224,13 +216,13 @@ public class DropTarget extends AbstractDefaultAjaxBehavior
 	protected void onComponentTag(ComponentTag tag)
 	{
 		super.onComponentTag(tag);
-		
+
 		tag.append("class", "dnd-drop-target", " ");
 	}
-	
+
 	/**
 	 * Get supported operations.
-	 * 
+	 *
 	 * @return operations
 	 * @see Transfer#getOperation()
 	 */
@@ -246,34 +238,52 @@ public class DropTarget extends AbstractDefaultAjaxBehavior
 
 		final String phase = readPhase(request);
 
-		final Location location = readLocation(request);
+		// Check if the target drop location exists
+		if (getLocationExists(request))
+		{
+			final Location location = readLocation(request);
 
-		if ("drag".equals(phase))
-		{
-			onDrag(target, location);
-		}
-		else if ("drop".equals(phase))
-		{
-			try
+			if ("drag".equals(phase))
 			{
-				final DragSource source = DragSource.read(getComponent().getPage(), request);
-
-				final Transfer transfer = readTransfer(request, source);
-
-				source.beforeDrop(request, transfer);
-
-				onDrop(target, transfer, location);
-
-				source.afterDrop(target, transfer);
-			}
-			catch (Reject reject)
+				onDrag(target, location);
+			} else if ("drop".equals(phase))
 			{
-				onRejected(target);
+				try
+				{
+					// Check if the drag source exists
+					if (DragSource.getDragSourceExists(getComponent().getPage(), request))
+					{
+						final DragSource source = DragSource.read(getComponent().getPage(), request);
+
+						final Transfer transfer = readTransfer(request, source);
+
+						// Check if the dragged component still exists
+						if (source.getDragComponentExists(request))
+						{
+							source.beforeDrop(request, transfer);
+
+							onDrop(target, transfer, location);
+
+							source.afterDrop(target, transfer);
+						} else
+						{
+							transfer.reject();
+						}
+					} else
+					{
+						onRejected(target);
+					}
+				} catch (Reject reject)
+				{
+					onRejected(target);
+				}
+			} else
+			{
+				throw new WicketRuntimeException("unkown phase '" + phase + "'");
 			}
-		}
-		else
+		} else
 		{
-			throw new WicketRuntimeException("unkown phase '" + phase + "'");
+			onRejected(target);
 		}
 	}
 
@@ -284,8 +294,8 @@ public class DropTarget extends AbstractDefaultAjaxBehavior
 
 	private Transfer readTransfer(Request request, DragSource source)
 	{
-		Operation operation = Operation.valueOf(request.getRequestParameters().getParameterValue(
-				"operation").toString());
+		Operation operation = Operation
+				.valueOf(request.getRequestParameters().getParameterValue("operation").toString());
 
 		if (!hasOperation(operation) || !source.hasOperation(operation))
 		{
@@ -293,7 +303,7 @@ public class DropTarget extends AbstractDefaultAjaxBehavior
 		}
 
 		List<String> transfers = new ArrayList<String>();
-		for (String transfer : this.getTypes())
+		for (String transfer : getTypes())
 		{
 			transfers.add(transfer);
 		}
@@ -313,20 +323,18 @@ public class DropTarget extends AbstractDefaultAjaxBehavior
 
 	private Location readLocation(Request request)
 	{
-		String id = getComponent().getRequest().getRequestParameters().getParameterValue(
-				"component").toString();
+		String id = getComponent().getRequest().getRequestParameters().getParameterValue("component").toString();
 
-		Component component = MarkupIdVisitor.getComponent((MarkupContainer)getComponent(), id);
+		Component component = MarkupIdVisitor.getComponent((MarkupContainer) getComponent(), id);
 
-		Anchor anchor = Anchor.valueOf(request.getRequestParameters().getParameterValue("anchor")
-				.toString());
+		Anchor anchor = Anchor.valueOf(request.getRequestParameters().getParameterValue("anchor").toString());
 
 		return new Location(component, anchor);
 	}
 
 	/**
 	 * Notification that a drag happend over this drop target.
-	 * 
+	 *
 	 * @param target
 	 *            initiating request target
 	 * @param location
@@ -337,10 +345,9 @@ public class DropTarget extends AbstractDefaultAjaxBehavior
 	}
 
 	/**
-	 * Notification that a drop happend on this drop target.
-	 * 
-	 * The default implementation always rejects the drop.
-	 * 
+	 * Notification that a drop happend on this drop target. The default
+	 * implementation always rejects the drop.
+	 *
 	 * @param target
 	 *            initiating request target
 	 * @param transfer
@@ -350,8 +357,7 @@ public class DropTarget extends AbstractDefaultAjaxBehavior
 	 * @throws Reject
 	 *             may reject the drop
 	 */
-	public void onDrop(AjaxRequestTarget target, Transfer transfer, Location location)
-			throws Reject
+	public void onDrop(AjaxRequestTarget target, Transfer transfer, Location location) throws Reject
 	{
 		transfer.reject();
 	}
@@ -359,11 +365,19 @@ public class DropTarget extends AbstractDefaultAjaxBehavior
 	/**
 	 * Hook method to handle rejected drops. Default implementation does
 	 * nothing.
-	 * 
+	 *
 	 * @param target
 	 *            initiating request target
 	 */
 	public void onRejected(AjaxRequestTarget target)
 	{
 	}
+
+	public boolean getLocationExists(Request request)
+	{
+		String id = getComponent().getRequest().getRequestParameters().getParameterValue("component").toString();
+
+		return MarkupIdVisitor.getComponentExists((MarkupContainer) getComponent(), id);
+	}
+
 }

--- a/wicket-dnd/src/main/java/wicketdnd/util/MarkupIdVisitor.java
+++ b/wicket-dnd/src/main/java/wicketdnd/util/MarkupIdVisitor.java
@@ -23,29 +23,35 @@ import org.apache.wicket.util.visit.IVisitor;
 
 /**
  * Find a child component by it's markup id.
- * 
+ *
  * @author Sven Meier
  */
-public class MarkupIdVisitor implements IVisitor<Component,Component> {
+public class MarkupIdVisitor implements IVisitor<Component, Component>
+{
 
 	private final String id;
 
-	public MarkupIdVisitor(String id) {
-		if (id == null) {
+	public MarkupIdVisitor(String id)
+	{
+		if (id == null)
+		{
 			throw new IllegalArgumentException("id must not be null");
 		}
 		this.id = id;
 	}
 
-	public void component(Component component, final IVisit<Component> visit) {
-		if (id.equals(component.getMarkupId(false))) {
+	@Override
+	public void component(Component component, final IVisit<Component> visit)
+	{
+		if (this.id.equals(component.getMarkupId(false)))
+		{
 			visit.stop(component);
 		}
 	}
 
 	/**
 	 * Get the given container's descendent by markup id.
-	 * 
+	 *
 	 * @param container
 	 *            container to find descendent of
 	 * @param id
@@ -54,18 +60,37 @@ public class MarkupIdVisitor implements IVisitor<Component,Component> {
 	 * @throws PageExpiredException
 	 *             if no descendent has the given markup id
 	 */
-	public static Component getComponent(MarkupContainer container, String id) {
-		if (id.equals(container.getMarkupId(false))) {
+	public static Component getComponent(MarkupContainer container, String id)
+	{
+		if (id.equals(container.getMarkupId(false)))
+		{
 			return container;
 		}
-		
-		Component component = container
-				.visitChildren(new MarkupIdVisitor(id));
 
-		if (component == null) {
+		Component component = container.visitChildren(new MarkupIdVisitor(id));
+
+		if (component == null)
+		{
 			throw new PageExpiredException("No component with markup id " + id);
 		}
 
 		return component;
+	}
+
+	public static boolean getComponentExists(MarkupContainer container, String id)
+	{
+		if (id.equals(container.getMarkupId(false)))
+		{
+			return true;
+		}
+
+		Component component = container.visitChildren(new MarkupIdVisitor(id));
+
+		if (component == null)
+		{
+			return false;
+		}
+
+		return true;
 	}
 }


### PR DESCRIPTION
Hi Sven,

Here is a pull request. I could not get the built-in Eclipse formatter to format the code exactly like yours, so the diff contains more changes than just the functional one. (I think you even use different formats for files, because I noticed sometimes the open braces are on a newline, sometimes trailing)
Maybe you just want to ignore this pull request and just take the relevant portions. 

The main changes are that both the `DragSoruce` and the `DropTarget` check if the markupId is still valid. If not, the `Transfer` will be rejected. 

Maybe a even better solution would be to follow an `onNoLongerValid()` path, but for now it prevents `PageExpiredExceptions`. Our end-users this will benefit, because they no longer have to start-over when constructing filters using dnd, it just silently fails now. 

I think ideally drag-n-drop should be prevented (this could be done by either putting a veil on the entire page, or disabling drag-n-drop javascript on the global ajax handlers).
   